### PR TITLE
option: Add `Reverse`

### DIFF
--- a/table/option/query.go
+++ b/table/option/query.go
@@ -23,6 +23,18 @@ func Index(indexName string) QueryInput {
 	}
 }
 
+// Reverse sets ScanIndexForward false in dynamodb.QueryInput.
+//
+// If ScanIndexForward is true, DynamoDB returns the results in ascending order, by range key.
+// This is the default behavior.
+//
+// If ScanIndexForward is false, DynamoDB returns the results in descending order, by range key.
+func Reverse() QueryInput {
+	return func(req *dynamodb.QueryInput) {
+		req.ScanIndexForward = aws.Bool(false)
+	}
+}
+
 // QueryConsistentRead enables consistent read in dynamodb.QueryInput.
 func QueryConsistentRead() QueryInput {
 	return func(req *dynamodb.QueryInput) {


### PR DESCRIPTION
`Reverse` option is added to get results in descending order, by range key.
`ScanIndexForward` parameter of DynamoDB is used by `Reverse` option.