### PR TITLE
Allow for returning output when updating items

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ aws-go-dynamodb is a Amazon DynamoDB library built with [aws/aws-sdk-go](https:/
 
 ## Testing
 
-If you want to run the tests, you *SHOULD* use a decicated DynamoDB table for the tests.
+If you want to run the tests, you *SHOULD* use a dedicated DynamoDB table for the tests.
 
-You can specify the table name in environment variable.
+You can specify the table name in an environment variable.
 
 ```sh
 $ cd table

--- a/table/option/update.go
+++ b/table/option/update.go
@@ -42,3 +42,11 @@ func UpdateExpressionAttributeValue(placeholder string, value *dynamodb.Attribut
 		req.ExpressionAttributeValues[placeholder] = value
 	}
 }
+
+// UpdateReturnValues sets the attributes to return in  dynamodb.UpdateItemOutput.
+// Default is dynamodb.ReturnValueNone.
+func UpdateReturnValues(returnValue string) UpdateItemInput {
+	return func(req *dynamodb.UpdateItemInput) {
+		req.ReturnValues = aws.String(returnValue)
+	}
+}

--- a/table/table.go
+++ b/table/table.go
@@ -84,7 +84,7 @@ func (t *Table) PutItem(v interface{}, opts ...option.PutItemInput) error {
 }
 
 // UpdateItem updates the item on the table.
-func (t *Table) UpdateItem(hashKeyValue, rangeKeyValue *dynamodb.AttributeValue, opts ...option.UpdateItemInput) error {
+func (t *Table) UpdateItem(hashKeyValue, rangeKeyValue *dynamodb.AttributeValue, opts ...option.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
 	req := &dynamodb.UpdateItemInput{
 		TableName: t.Name,
 	}
@@ -102,8 +102,7 @@ func (t *Table) UpdateItem(hashKeyValue, rangeKeyValue *dynamodb.AttributeValue,
 		f(req)
 	}
 
-	_, err := t.DynamoDB.UpdateItem(req)
-	return err
+	return t.DynamoDB.UpdateItem(req)
 }
 
 // GetItem get the item from the table and convert it to v.

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -168,7 +168,7 @@ func TestTable(t *testing.T) {
 
 	// Update the item with incrementing counter and setting role as StringSet
 	{
-		err := dtable.UpdateItem(
+		_, err := dtable.UpdateItem(
 			hashKey,
 			rangeKey,
 			option.UpdateExpressionAttributeName("login_count", "#count"),
@@ -197,7 +197,7 @@ func TestTable(t *testing.T) {
 
 	// Update the item with decrementing counter and removing role
 	{
-		err := dtable.UpdateItem(
+		_, err := dtable.UpdateItem(
 			hashKey,
 			rangeKey,
 			option.UpdateExpressionAttributeName("login_count", "#count"),


### PR DESCRIPTION
So it's a fairly small change, but it just allows consumers of the library access to the output object of dynamodb's `UpdateItem`.
For convenience, I've also added an `option.UpdateReturnValues` function that will allow a consumer to easily set the `ReturnValues` of the input and hence allow them to easily get back the latest updated item