### PR TITLE
feat: convert the functional option pattern with the interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ assert.True(t, errors.As(err, &exception))
 assert.Equal(t, "ConditionalCheckFailedException", exception.ErrorCode())
 ```
 
+**Handling options**:
+
+The option appliers are converted into an interface from the optional function pattern.
+
+Example:
+```go
+dtable.GetItem(context.TODO(), hashKey, rangeKey, &actualItem, option.ConsistentRead(true))
+```
+
 ## v1
 
 If you want to use this library with `aws-sdk-go`, please use v1 version of the library.

--- a/table/option/delete.go
+++ b/table/option/delete.go
@@ -2,33 +2,9 @@ package option
 
 import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-// The DeleteItemInput type is an adapter to change a parameter in
-// dynamodb.DeleteItemInput
-type DeleteItemInput func(req *dynamodb.DeleteItemInput)
-
-// DeleteExpressionAttributeNames sets ExpressionAttributeNames in dynamodb.DeleteItemInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build names.
-func DeleteExpressionAttributeNames(names map[string]string) DeleteItemInput {
-	return func(req *dynamodb.DeleteItemInput) {
-		req.ExpressionAttributeNames = names
-	}
-}
-
-// DeleteExpressionAttributeValues sets an ExpressionAttributeValues in dynamodb.DeleteItemInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build values.
-func DeleteExpressionAttributeValues(values map[string]types.AttributeValue) DeleteItemInput {
-	return func(req *dynamodb.DeleteItemInput) {
-		req.ExpressionAttributeValues = values
-	}
-}
-
-// DeleteCondition sets a condition expression in dynamodb.DeleteItemInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build cond.
-func DeleteCondition(cond *string) DeleteItemInput {
-	return func(req *dynamodb.DeleteItemInput) {
-		req.ConditionExpression = cond
-	}
+// DeleteItemInputOption is an interface to apply an option to dynamodb.DeleteItemInput.
+type DeleteItemInputOption interface {
+	ApplyToDeleteItemInput(req *dynamodb.DeleteItemInput)
 }

--- a/table/option/get.go
+++ b/table/option/get.go
@@ -1,17 +1,10 @@
 package option
 
 import (
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 )
 
-// The GetItemInput type is an adapter to change a parameter in
-// dynamodb.GetItemInput
-type GetItemInput func(req *dynamodb.GetItemInput)
-
-// ConsistentRead enables ConsistentRead in dynamodb.GetItemInput.
-func ConsistentRead() GetItemInput {
-	return func(req *dynamodb.GetItemInput) {
-		req.ConsistentRead = aws.Bool(true)
-	}
+// GetItemInputOption is an interface to apply an option to dynamodb.GetItemInputOption.
+type GetItemInputOption interface {
+	ApplyToGetItemInput(req *dynamodb.GetItemInput)
 }

--- a/table/option/options.go
+++ b/table/option/options.go
@@ -1,0 +1,154 @@
+package option
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// ExpressionAttributeNames is a type that can apply ExpressionAttributeNames to the various input parameters.
+type ExpressionAttributeNames map[string]string
+
+// ApplyToDeleteItemInput applies the option to dynamodb.DeleteItemInput.
+func (names ExpressionAttributeNames) ApplyToDeleteItemInput(req *dynamodb.DeleteItemInput) {
+	req.ExpressionAttributeNames = names
+}
+
+// ApplyToPutItemInput applies the option to dynamodb.PutItemInput.
+func (names ExpressionAttributeNames) ApplyToPutItemInput(req *dynamodb.PutItemInput) {
+	req.ExpressionAttributeNames = names
+}
+
+// ApplyToUpdateItemInput applies the option to dynamodb.UpdateItemInput.
+func (names ExpressionAttributeNames) ApplyToUpdateItemInput(req *dynamodb.UpdateItemInput) {
+	req.ExpressionAttributeNames = names
+}
+
+// ApplyToQueryInput applies the option to dynamodb.QueryInput.
+func (names ExpressionAttributeNames) ApplyToQueryInput(req *dynamodb.QueryInput) {
+	req.ExpressionAttributeNames = names
+}
+
+// ExpressionAttributeValues is a type that can apply ExpressionAttributeValues to the various input parameters.
+type ExpressionAttributeValues map[string]types.AttributeValue
+
+// ApplyToDeleteItemInput applies the option to dynamodb.DeleteItemInput.
+func (values ExpressionAttributeValues) ApplyToDeleteItemInput(req *dynamodb.DeleteItemInput) {
+	req.ExpressionAttributeValues = values
+}
+
+// ApplyToPutItemInput applies the option to dynamodb.PutItemInput.
+func (values ExpressionAttributeValues) ApplyToPutItemInput(req *dynamodb.PutItemInput) {
+	req.ExpressionAttributeValues = values
+}
+
+// ApplyToUpdateItemInput applies the option to dynamodb.UpdateItemInput.
+func (values ExpressionAttributeValues) ApplyToUpdateItemInput(req *dynamodb.UpdateItemInput) {
+	req.ExpressionAttributeValues = values
+}
+
+// ApplyToQueryInput applies the option to dynamodb.QueryInput.
+func (values ExpressionAttributeValues) ApplyToQueryInput(req *dynamodb.QueryInput) {
+	req.ExpressionAttributeValues = values
+}
+
+// Condition is a type that can apply ConditionExpression to the various input parameters.
+type Condition string
+
+// ApplyToDeleteItemInput applies the option to dynamodb.DeleteItemInput.
+func (c *Condition) ApplyToDeleteItemInput(req *dynamodb.DeleteItemInput) {
+	req.ConditionExpression = (*string)(c)
+}
+
+// ApplyToPutItemInput applies the option to dynamodb.PutItemInput.
+func (c *Condition) ApplyToPutItemInput(req *dynamodb.PutItemInput) {
+	req.ConditionExpression = (*string)(c)
+}
+
+// ApplyToUpdateItemInput applies the option to dynamodb.UpdateItemInput.
+func (c *Condition) ApplyToUpdateItemInput(req *dynamodb.PutItemInput) {
+	req.ConditionExpression = (*string)(c)
+}
+
+// ConsistentRead is a type that can apply ConsistentRead to the various input parameters.
+type ConsistentRead bool
+
+// ApplyToGetItemInput applies the option to dynamodb.GetItemInput.
+func (cr ConsistentRead) ApplyToGetItemInput(req *dynamodb.GetItemInput) {
+	req.ConsistentRead = (*bool)(&cr)
+}
+
+// Limit is a type that can apply Limit to the various input parameters.
+type Limit int32
+
+// ApplyToQueryInput applies the option to dynamodb.QueryInput.
+func (l Limit) ApplyToQueryInput(req *dynamodb.QueryInput) {
+	req.Limit = (*int32)(&l)
+}
+
+// Index is a type that can apply IndexName to the various input parameters.
+type Index string
+
+// ApplyToQueryInput applies the option to dynamodb.QueryInput.
+func (i Index) ApplyToQueryInput(req *dynamodb.QueryInput) {
+	req.IndexName = (*string)(&i)
+}
+
+// ProjectionExpression is type that can apply ProjectionExpression to the various input parameters.
+type ProjectionExpression string
+
+// ApplyToQueryInput applies the option to dynamodb.QueryInput.
+func (e *ProjectionExpression) ApplyToQueryInput(req *dynamodb.QueryInput) {
+	req.ProjectionExpression = (*string)(e)
+}
+
+// Reverse is a type that can apply ScanIndexForward to the various input parameters.
+//
+// If ScanIndexForward is true, DynamoDB returns the results in ascending order, by range key.
+// This is the DynamoDB's default behavior.
+//
+// If ScanIndexForward is false, DynamoDB returns the results in descending order, by range key.
+//
+// If Reverse is true, it will set ScanIndexForward to false to get a reversed result.
+type Reverse bool
+
+// ApplyToQueryInput applies the option to dynamodb.QueryInput.
+func (r Reverse) ApplyToQueryInput(req *dynamodb.QueryInput) {
+	if r {
+		req.ScanIndexForward = aws.Bool(false)
+	} else {
+		req.ScanIndexForward = (*bool)(&r)
+	}
+}
+
+// ExclusiveStartKey is a type that can apply ExclusiveStartKey to the various input parameters.
+type ExclusiveStartKey map[string]types.AttributeValue
+
+// ApplyToQueryInput applies the option to dynamodb.QueryInput.
+func (k ExclusiveStartKey) ApplyToQueryInput(req *dynamodb.QueryInput) {
+	req.ExclusiveStartKey = k
+}
+
+// FilterExpression is a type that can apply FilterExpression to the various input parameters.
+type FilterExpression string
+
+// ApplyToQueryInput applies the option to dynamodb.QueryInput.
+func (e *FilterExpression) ApplyToQueryInput(req *dynamodb.QueryInput) {
+	req.FilterExpression = (*string)(e)
+}
+
+// KeyConditionExpression is a type that can apply KeyConditionExpression to the various input parameter.
+type KeyConditionExpression string
+
+// ApplyToQueryInput applies the option appllies the option to dynamodb.QueryInput.
+func (e *KeyConditionExpression) ApplyToQueryInput(req *dynamodb.QueryInput) {
+	req.KeyConditionExpression = (*string)(e)
+}
+
+// ReturnValue is an type that can apply ReturnValues to the various input parameters.
+type ReturnValue types.ReturnValue
+
+// ApplyToUpdateItemInput applies the option to dynamodb.UpdateItemInput.
+func (v ReturnValue) ApplyToUpdateItemInput(req *dynamodb.UpdateItemInput) {
+	req.ReturnValues = (types.ReturnValue)(v)
+}

--- a/table/option/put.go
+++ b/table/option/put.go
@@ -2,33 +2,9 @@ package option
 
 import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-// The PutItemInput type is an adapter to change a parameter in
-// dynamodb.PutItemInput
-type PutItemInput func(req *dynamodb.PutItemInput)
-
-// PutCondition sets a condition expression in dynamodb.PutItemInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build cond.
-func PutCondition(cond *string) PutItemInput {
-	return func(req *dynamodb.PutItemInput) {
-		req.ConditionExpression = cond
-	}
-}
-
-// PutExpressionAttributeNames sets an ExpressionAttributeNames in dynamodb.PutItemInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build names.
-func PutExpressionAttributeNames(names map[string]string) PutItemInput {
-	return func(req *dynamodb.PutItemInput) {
-		req.ExpressionAttributeNames = names
-	}
-}
-
-// PutExpressionAttributeValues sets an ExpressionAttributeValues in dynamodb.PutItemInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build values.
-func PutExpressionAttributeValues(values map[string]types.AttributeValue) PutItemInput {
-	return func(req *dynamodb.PutItemInput) {
-		req.ExpressionAttributeValues = values
-	}
+// PutItemInputOption is an interface to apply an option to dynamodb.PutItemInput.
+type PutItemInputOption interface {
+	ApplyToPutItemInput(req *dynamodb.PutItemInput)
 }

--- a/table/option/query.go
+++ b/table/option/query.go
@@ -1,92 +1,10 @@
 package option
 
 import (
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-// The QueryInput type is an adapter to change a parameter in
-// dynamodb.QueryInput
-type QueryInput func(req *dynamodb.QueryInput)
-
-// Limit sets limit parameter in dynamodb.QueryInput.
-func Limit(limit int32) QueryInput {
-	return func(req *dynamodb.QueryInput) {
-		req.Limit = aws.Int32(limit)
-	}
-}
-
-// Index sets an index name in dynamodb.QueryInput.
-func Index(indexName string) QueryInput {
-	return func(req *dynamodb.QueryInput) {
-		req.IndexName = aws.String(indexName)
-	}
-}
-
-// ProjectionExpression sets ProjectionExpression in dynamodb.QueryInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build expression.
-func ProjectionExpression(expression *string) QueryInput {
-	return func(req *dynamodb.QueryInput) {
-		req.ProjectionExpression = expression
-	}
-}
-
-// Reverse sets ScanIndexForward false in dynamodb.QueryInput.
-//
-// If ScanIndexForward is true, DynamoDB returns the results in ascending order, by range key.
-// This is the default behavior.
-//
-// If ScanIndexForward is false, DynamoDB returns the results in descending order, by range key.
-func Reverse() QueryInput {
-	return func(req *dynamodb.QueryInput) {
-		req.ScanIndexForward = aws.Bool(false)
-	}
-}
-
-// QueryConsistentRead enables consistent read in dynamodb.QueryInput.
-func QueryConsistentRead() QueryInput {
-	return func(req *dynamodb.QueryInput) {
-		req.ConsistentRead = aws.Bool(true)
-	}
-}
-
-// ExclusiveStartKey sets an ExclusiveStartKey in dynamodb.QueryInput.
-// You can build esk with attributevalue.Marshal functon.
-func ExclusiveStartKey(esk map[string]types.AttributeValue) QueryInput {
-	return func(req *dynamodb.QueryInput) {
-		req.ExclusiveStartKey = esk
-	}
-}
-
-// QueryExpressionAttributeNames sets an ExpressionAttributeNames in dynamodb.QueryInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build names.
-func QueryExpressionAttributeNames(names map[string]string) QueryInput {
-	return func(req *dynamodb.QueryInput) {
-		req.ExpressionAttributeNames = names
-	}
-}
-
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build names.
-// QueryExpressionAttributeValues sets an ExpressionAttributeValues in dynamodb.QueryInput.
-func QueryExpressionAttributeValues(values map[string]types.AttributeValue) QueryInput {
-	return func(req *dynamodb.QueryInput) {
-		req.ExpressionAttributeValues = values
-	}
-}
-
-// QueryFilterExpression sets FilterExpression in dynamodb.QueryInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build expression.
-func QueryFilterExpression(expression *string) QueryInput {
-	return func(req *dynamodb.QueryInput) {
-		req.FilterExpression = expression
-	}
-}
-
-// QueryKeyConditionExpression sets KeyConditionExpression in dynamodb.QueryInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build expression.
-func QueryKeyConditionExpression(expression *string) QueryInput {
-	return func(req *dynamodb.QueryInput) {
-		req.KeyConditionExpression = expression
-	}
+// QueryInputOption is an interface to apply an option to dynamodb.QueryInput.
+type QueryInputOption interface {
+	ApplyToQueryInput(req *dynamodb.QueryInput)
 }

--- a/table/option/update.go
+++ b/table/option/update.go
@@ -2,49 +2,21 @@ package option
 
 import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-// The UpdateItemInput type is an adapter to change a parameter in
-// dynamodb.UpdateItemInput
-type UpdateItemInput func(req *dynamodb.UpdateItemInput)
+// UpdateItemInputOption is an interface to apply an option to dynamodb.UpdateItemInput.
+type UpdateItemInputOption interface {
+	ApplyToUpdateItemInput(req *dynamodb.UpdateItemInput)
+}
 
-// UpdateCondition sets a condition expression in dynamodb.UpdateItemInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build cond.
-func UpdateCondition(cond *string) UpdateItemInput {
-	return func(req *dynamodb.UpdateItemInput) {
-		req.ConditionExpression = cond
-	}
+type updateExpression string
+
+func (e *updateExpression) ApplyToUpdateItemInput(req *dynamodb.UpdateItemInput) {
+	req.UpdateExpression = (*string)(e)
 }
 
 // UpdateExpression sets a update expression in dynamodb.UpdateItemInput.
 // You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build expression.
-func UpdateExpression(expression *string) UpdateItemInput {
-	return func(req *dynamodb.UpdateItemInput) {
-		req.UpdateExpression = expression
-	}
-}
-
-// UpdateExpressionAttributeNames sets an ExpressionAttributeNames in dynamodb.UpdateItemInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build names.
-func UpdateExpressionAttributeNames(names map[string]string) UpdateItemInput {
-	return func(req *dynamodb.UpdateItemInput) {
-		req.ExpressionAttributeNames = names
-	}
-}
-
-// UpdateExpressionAttributeValues sets an ExpressionAttributeValues in dynamodb.UpdateItemInput.
-// You should use `aws-sdk-go-v2/feature/dynamodb/expression` package to build values.
-func UpdateExpressionAttributeValues(values map[string]types.AttributeValue) UpdateItemInput {
-	return func(req *dynamodb.UpdateItemInput) {
-		req.ExpressionAttributeValues = values
-	}
-}
-
-// UpdateReturnValues sets the attributes to return in dynamodb.UpdateItemOutput.
-// Default is dynamodb.ReturnValueNone.
-func UpdateReturnValues(returnValue types.ReturnValue) UpdateItemInput {
-	return func(req *dynamodb.UpdateItemInput) {
-		req.ReturnValues = returnValue
-	}
+func UpdateExpression(expression *string) UpdateItemInputOption {
+	return (*updateExpression)(expression)
 }

--- a/table/table.go
+++ b/table/table.go
@@ -56,7 +56,7 @@ func (t *Table) WithRangeKey(keyName string, keyAttributeType types.ScalarAttrib
 
 // PutItem puts an item on the table.
 // It invokes attributevalue.MarshalMap function to marshal v.
-func (t *Table) PutItem(ctx context.Context, v interface{}, opts ...option.PutItemInput) error {
+func (t *Table) PutItem(ctx context.Context, v interface{}, opts ...option.PutItemInputOption) error {
 	req := &dynamodb.PutItemInput{
 		TableName: t.Name,
 	}
@@ -69,7 +69,7 @@ func (t *Table) PutItem(ctx context.Context, v interface{}, opts ...option.PutIt
 	req.Item = itemMapped
 
 	for _, f := range opts {
-		f(req)
+		f.ApplyToPutItemInput(req)
 	}
 
 	_, err = t.DynamoDB.PutItem(ctx, req)
@@ -77,7 +77,7 @@ func (t *Table) PutItem(ctx context.Context, v interface{}, opts ...option.PutIt
 }
 
 // UpdateItem updates the item on the table.
-func (t *Table) UpdateItem(ctx context.Context, hashKeyValue, rangeKeyValue types.AttributeValue, opts ...option.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+func (t *Table) UpdateItem(ctx context.Context, hashKeyValue, rangeKeyValue types.AttributeValue, opts ...option.UpdateItemInputOption) (*dynamodb.UpdateItemOutput, error) {
 	req := &dynamodb.UpdateItemInput{
 		TableName: t.Name,
 	}
@@ -92,7 +92,7 @@ func (t *Table) UpdateItem(ctx context.Context, hashKeyValue, rangeKeyValue type
 	req.Key = key
 
 	for _, f := range opts {
-		f(req)
+		f.ApplyToUpdateItemInput(req)
 	}
 
 	return t.DynamoDB.UpdateItem(ctx, req)
@@ -100,7 +100,7 @@ func (t *Table) UpdateItem(ctx context.Context, hashKeyValue, rangeKeyValue type
 
 // GetItem get the item from the table and convert it to v.
 // It invokes attributevalue.UnmarshalMap function to unmarshal an item into v.
-func (t *Table) GetItem(ctx context.Context, hashKeyValue, rangeKeyValue types.AttributeValue, v interface{}, opts ...option.GetItemInput) error {
+func (t *Table) GetItem(ctx context.Context, hashKeyValue, rangeKeyValue types.AttributeValue, v interface{}, opts ...option.GetItemInputOption) error {
 	req := &dynamodb.GetItemInput{
 		TableName: t.Name,
 	}
@@ -115,7 +115,7 @@ func (t *Table) GetItem(ctx context.Context, hashKeyValue, rangeKeyValue types.A
 	req.Key = key
 
 	for _, f := range opts {
-		f(req)
+		f.ApplyToGetItemInput(req)
 	}
 
 	resp, err := t.DynamoDB.GetItem(ctx, req)
@@ -132,13 +132,13 @@ func (t *Table) GetItem(ctx context.Context, hashKeyValue, rangeKeyValue types.A
 
 // Query queries items to the table and convert it to v. v must be a slice of struct.
 // If the Query operation does not return the last page, LastEvaluatedKey will be returned.
-func (t *Table) Query(ctx context.Context, slice interface{}, opts ...option.QueryInput) (map[string]types.AttributeValue, error) {
+func (t *Table) Query(ctx context.Context, slice interface{}, opts ...option.QueryInputOption) (map[string]types.AttributeValue, error) {
 	req := &dynamodb.QueryInput{
 		TableName: t.Name,
 	}
 
 	for _, f := range opts {
-		f(req)
+		f.ApplyToQueryInput(req)
 	}
 
 	resp, err := t.DynamoDB.Query(ctx, req)
@@ -154,7 +154,7 @@ func (t *Table) Query(ctx context.Context, slice interface{}, opts ...option.Que
 }
 
 // DeleteItem deletes the item in the table.
-func (t *Table) DeleteItem(ctx context.Context, hashKeyValue, rangeKeyValue types.AttributeValue, opts ...option.DeleteItemInput) error {
+func (t *Table) DeleteItem(ctx context.Context, hashKeyValue, rangeKeyValue types.AttributeValue, opts ...option.DeleteItemInputOption) error {
 	req := &dynamodb.DeleteItemInput{
 		TableName: t.Name,
 	}
@@ -169,7 +169,7 @@ func (t *Table) DeleteItem(ctx context.Context, hashKeyValue, rangeKeyValue type
 	req.Key = key
 
 	for _, f := range opts {
-		f(req)
+		f.ApplyToDeleteItemInput(req)
 	}
 
 	_, err := t.DynamoDB.DeleteItem(ctx, req)

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -179,7 +179,7 @@ func TestTable(t *testing.T) {
 		rangeKey := attributes.Number(items[0].Date)
 
 		var actualItem TestItem
-		err := dtable.GetItem(context.TODO(), hashKey, rangeKey, &actualItem, option.ConsistentRead())
+		err := dtable.GetItem(context.TODO(), hashKey, rangeKey, &actualItem, option.ConsistentRead(true))
 		require.Error(t, err)
 		assert.ErrorIs(t, err, table.ErrItemNotFound)
 	})
@@ -204,8 +204,8 @@ func TestTable(t *testing.T) {
 		err = dtable.PutItem(
 			context.TODO(),
 			items[0],
-			option.PutExpressionAttributeNames(expr.Names()),
-			option.PutCondition(expr.Condition()),
+			option.ExpressionAttributeNames(expr.Names()),
+			(*option.Condition)(expr.Condition()),
 		)
 
 		require.Error(t, err)
@@ -257,8 +257,8 @@ func TestTable(t *testing.T) {
 			context.TODO(),
 			hashKey,
 			rangeKey,
-			option.UpdateExpressionAttributeNames(expr.Names()),
-			option.UpdateExpressionAttributeValues(expr.Values()),
+			option.ExpressionAttributeNames(expr.Names()),
+			option.ExpressionAttributeValues(expr.Values()),
 			option.UpdateExpression(expr.Update()),
 		)
 
@@ -267,7 +267,7 @@ func TestTable(t *testing.T) {
 		t.Run("Assert SET and ADD operation", func(t *testing.T) {
 			// confirm the result
 			var actualItem TestItem
-			if err := dtable.GetItem(context.TODO(), hashKey, rangeKey, &actualItem, option.ConsistentRead()); err != nil {
+			if err := dtable.GetItem(context.TODO(), hashKey, rangeKey, &actualItem, option.ConsistentRead(true)); err != nil {
 				t.Error(err)
 			}
 
@@ -301,8 +301,8 @@ func TestTable(t *testing.T) {
 				context.TODO(),
 				hashKey,
 				rangeKey,
-				option.UpdateExpressionAttributeNames(expr.Names()),
-				option.UpdateExpressionAttributeValues(expr.Values()),
+				option.ExpressionAttributeNames(expr.Names()),
+				option.ExpressionAttributeValues(expr.Values()),
 				option.UpdateExpression(expr.Update()),
 			)
 
@@ -310,7 +310,7 @@ func TestTable(t *testing.T) {
 
 			// confirm the result
 			var actualItem TestItem
-			if err := dtable.GetItem(context.TODO(), hashKey, rangeKey, &actualItem, option.ConsistentRead()); err != nil {
+			if err := dtable.GetItem(context.TODO(), hashKey, rangeKey, &actualItem, option.ConsistentRead(true)); err != nil {
 				t.Error(err)
 			}
 
@@ -342,9 +342,9 @@ func TestTable(t *testing.T) {
 			lastEvaluatedKey, err := dtable.Query(
 				context.TODO(),
 				&actualItems,
-				option.QueryKeyConditionExpression(expr.KeyCondition()),
-				option.QueryExpressionAttributeNames(expr.Names()),
-				option.QueryExpressionAttributeValues(expr.Values()),
+				(*option.KeyConditionExpression)(expr.KeyCondition()),
+				option.ExpressionAttributeNames(expr.Names()),
+				option.ExpressionAttributeValues(expr.Values()),
 			)
 
 			assert.NoError(t, err)
@@ -357,10 +357,10 @@ func TestTable(t *testing.T) {
 			lastEvaluatedKey, err := dtable.Query(
 				context.TODO(),
 				&actualItems,
-				option.Reverse(),
-				option.QueryKeyConditionExpression(expr.KeyCondition()),
-				option.QueryExpressionAttributeNames(expr.Names()),
-				option.QueryExpressionAttributeValues(expr.Values()),
+				option.Reverse(true),
+				(*option.KeyConditionExpression)(expr.KeyCondition()),
+				option.ExpressionAttributeNames(expr.Names()),
+				option.ExpressionAttributeValues(expr.Values()),
 			)
 
 			assert.NoError(t, err)
@@ -384,9 +384,9 @@ func TestTable(t *testing.T) {
 				lastEvaluatedKey, err := dtable.Query(
 					context.TODO(),
 					&actualItems,
-					option.QueryKeyConditionExpression(expr.KeyCondition()),
-					option.QueryExpressionAttributeNames(expr.Names()),
-					option.QueryExpressionAttributeValues(expr.Values()),
+					(*option.KeyConditionExpression)(expr.KeyCondition()),
+					option.ExpressionAttributeNames(expr.Names()),
+					option.ExpressionAttributeValues(expr.Values()),
 					option.ExclusiveStartKey(items[i].PrimaryKey()),
 				)
 
@@ -409,9 +409,9 @@ func TestTable(t *testing.T) {
 			_, err = dtable.Query(
 				context.TODO(),
 				&invalidActualItem,
-				option.QueryKeyConditionExpression(expr.KeyCondition()),
-				option.QueryExpressionAttributeNames(expr.Names()),
-				option.QueryExpressionAttributeValues(expr.Values()),
+				(*option.KeyConditionExpression)(expr.KeyCondition()),
+				option.ExpressionAttributeNames(expr.Names()),
+				option.ExpressionAttributeValues(expr.Values()),
 			)
 
 			assert.ErrorContains(t, err, "unmarshal failed")
@@ -429,10 +429,10 @@ func TestTable(t *testing.T) {
 			_, err = dtable.Query(
 				context.TODO(),
 				&actualItems,
-				option.QueryKeyConditionExpression(expr.KeyCondition()),
-				option.QueryExpressionAttributeNames(expr.Names()),
-				option.QueryExpressionAttributeValues(expr.Values()),
-				option.ProjectionExpression(expr.Projection()),
+				(*option.KeyConditionExpression)(expr.KeyCondition()),
+				option.ExpressionAttributeNames(expr.Names()),
+				option.ExpressionAttributeValues(expr.Values()),
+				(*option.ProjectionExpression)(expr.Projection()),
 			)
 
 			assert.NoError(t, err)
@@ -467,9 +467,9 @@ func TestTable(t *testing.T) {
 			hashKey,
 			rangeKey,
 
-			option.DeleteExpressionAttributeNames(expr.Names()),
-			option.DeleteExpressionAttributeValues(expr.Values()),
-			option.DeleteCondition(expr.Condition()),
+			option.ExpressionAttributeNames(expr.Names()),
+			option.ExpressionAttributeValues(expr.Values()),
+			(*option.Condition)(expr.Condition()),
 		)
 
 		require.Error(t, err)
@@ -509,9 +509,9 @@ func TestTable(t *testing.T) {
 				hashKey,
 				rangeKey,
 
-				option.DeleteExpressionAttributeNames(expr.Names()),
-				option.DeleteExpressionAttributeValues(expr.Values()),
-				option.DeleteCondition(expr.Condition()),
+				option.ExpressionAttributeNames(expr.Names()),
+				option.ExpressionAttributeValues(expr.Values()),
+				(*option.Condition)(expr.Condition()),
 			)
 
 			require.NoError(t, err)


### PR DESCRIPTION
## Changes

While looking at `aws-sdk-go-v2` code, I found that they follows interface-based functional option pattern. I think it would be great to convert the codebase as well.